### PR TITLE
fix a crash related to observing released tableview

### DIFF
--- a/RKParallaxEffect/RKParallaxEffect/RKParallaxEffect.swift
+++ b/RKParallaxEffect/RKParallaxEffect/RKParallaxEffect.swift
@@ -37,9 +37,13 @@ public class RKParallaxEffect: NSObject {
                     isFullScreenModeEnabled = true
                 }
                 tableHeaderView?.userInteractionEnabled = true
-                tableHeaderView?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: Selector("handleTap:")))
+                tableHeaderView?.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(RKParallaxEffect.handleTap(_:))))
             }
         }
+    }
+    
+    deinit {
+        removeObservers()
     }
     
     var newFrame: CGRect {


### PR DESCRIPTION
Easy steps to reproduce:
1. push a table view controller with this parallax effect
2. dismiss presented view controller.
3. It will crash because the parallaxEffect object still observe
   released table view
